### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ apex
 scipy
 dataclass_wizard
 cpm_kernels
+numpy==1.20.3


### PR DESCRIPTION
add numpy==1.20.3 

fix bug: https://github.com/THUDM/GLM-130B/issues/168

修复安装 numpy （>=1.24.3） 更新版本导致的报错